### PR TITLE
Ignore unneeded files in npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,16 @@
 /browser.js
 /build
-/demo
+/dist/demo
 /Makefile
 /node_modules
 /src
 /test
+
+/.ackrc
+/.babelrc
+/.editorconfig
+/todo.md
+/karma.conf.js
+/webpack.config.babel.js
+/yarn-error.log
+/yarn.lock


### PR DESCRIPTION
This adds several files to .npmignore to help trimming down the size of the npm package.

Looking at: https://unpkg.com/dagre-d3-renderer@0.5.8/ I found that the following files are not needed by the package and can be ignored safely