### PR TITLE
Use babel-plugin-lodash to redue bundle size

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,7 @@
 {
+  "plugins": [
+    "lodash"
+  ],
   "presets": [
     "env"
   ]

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.3",
+    "babel-plugin-lodash": "^2.3.0",
     "babel-preset-env": "^1.6.1",
     "chai": "^4.1.2",
     "husky": "^0.14.3",

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -18,7 +18,6 @@ const config = {
     rules: [
       {
         test: /\.js$/,
-        exclude: /node_modules/,
         use: {
           loader: 'babel-loader'
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -553,6 +553,13 @@ babel-plugin-check-es2015-constants@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
+babel-plugin-lodash@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-lodash/-/babel-plugin-lodash-2.3.0.tgz#4166c8f3ca52aa95be9e1839d24583e70a857ec2"
+  integrity sha1-QWbI88pSqpW+nhg50kWD5wqFfsI=
+  dependencies:
+    lodash "^4.0.0"
+
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"


### PR DESCRIPTION
Fix for #5 using babel-plugin-lodash

Before,
```
Version: webpack 4.0.1
Child
    Hash: 942631aacfb8e1214122
    Time: 15022ms
    Built at: 30/06/2019 18:57:33
              Asset      Size    Chunks                    Chunk Names
        dagre-d3.js  3.12 MiB  dagre-d3  [emitted]  [big]  dagre-d3
    dagre-d3.js.map  3.39 MiB  dagre-d3  [emitted]         dagre-d3
    Entrypoint dagre-d3 [big] = dagre-d3.js dagre-d3.js.map
```

After,
```
Version: webpack 4.0.1
Child
    Hash: 8270ccb85e57fb1556f3
    Time: 11849ms
    Built at: 30/06/2019 18:59:18
              Asset      Size    Chunks                    Chunk Names
        dagre-d3.js  1.87 MiB  dagre-d3  [emitted]  [big]  dagre-d3
    dagre-d3.js.map  2.59 MiB  dagre-d3  [emitted]         dagre-d3
    Entrypoint dagre-d3 [big] = dagre-d3.js dagre-d3.js.map
```